### PR TITLE
Prevent bot buying if both TBP and pDiv are 0

### DIFF
--- a/src/server/qe.h
+++ b/src/server/qe.h
@@ -244,7 +244,7 @@ namespace K {
             if (!QP::getBool("buySizeMax")) rawQuote.bid.size = fmin(QP::getInt("aprMultiplier")*buySize, fmin(pgTargetBasePos - totalBasePosition, (pgPos.quoteAmount / mgFairValue) / 2));
           }
         }
-        else if (totalBasePosition > pgTargetBasePos + pDiv) {
+        else if (totalBasePosition >= pgTargetBasePos + pDiv) {
           qeBidStatus = mQuoteState::TBPHeld;
           rawQuote.bid.price = 0;
           rawQuote.bid.size = 0;


### PR DESCRIPTION
If TBP is 0 and the user has also set pDiv to 0, the bot continually buys and sells 1 trade. This change prevents the bot from buying. 