### PR TITLE
Fix Bitfi not enough exchange balance error

### DIFF
--- a/src/server/qe.h
+++ b/src/server/qe.h
@@ -102,6 +102,14 @@ namespace K {
           and abs(qeQuote.bid.size - quote.bid.size) < gw->minSize
           and abs(qeQuote.ask.size - quote.ask.size) < gw->minSize
         )) return;
+       if ( quote.bid.size and quote.bid.size > ((pgPos.quoteAmount + pgPos.quoteHeldAmount) / mgFairValue )) {
+	        if (argDebugQuotes) FN::log("DEBUG", string("QE ERROR insufficient funds to BUY"));
+	        return;
+	        }
+	    if ( quote.ask.size and quote.ask.size > (pgPos.baseAmount + pgPos.baseHeldAmount) ) {
+	        if (argDebugQuotes) FN::log("DEBUG", string("QE ERROR insufficient funds to SELL"));
+	        return;
+	        } 
         qeQuote = quote;
         if (argDebugQuotes) FN::log("DEBUG", string("QE quote! ") + ((json)qeQuote).dump());
         send();

--- a/src/server/qe.h
+++ b/src/server/qe.h
@@ -103,12 +103,12 @@ namespace K {
           and abs(qeQuote.ask.size - quote.ask.size) < gw->minSize
         )) return;
        if ( quote.bid.size and quote.bid.size > ((pgPos.quoteAmount + pgPos.quoteHeldAmount) / mgFairValue )) {
-	        if (argDebugQuotes) FN::log("DEBUG", string("QE ERROR insufficient funds to BUY"));
-	        return;
+	        if (argDebugQuotes) FN::log("DEBUG", string("QE ERROR depleted funds to BUY"));
+	        qeBidStatus = mQuoteState::DepletedFunds;
 	        }
 	    if ( quote.ask.size and quote.ask.size > (pgPos.baseAmount + pgPos.baseHeldAmount) ) {
-	        if (argDebugQuotes) FN::log("DEBUG", string("QE ERROR insufficient funds to SELL"));
-	        return;
+	        if (argDebugQuotes) FN::log("DEBUG", string("QE ERROR depleted funds to SELL"));
+	        qeAskStatus = mQuoteState::DepletedFunds;
 	        } 
         qeQuote = quote;
         if (argDebugQuotes) FN::log("DEBUG", string("QE quote! ") + ((json)qeQuote).dump());


### PR DESCRIPTION
Hey Charles,

this one is for all the unlucky traders like me...

when K burned up all the money and the funds are less than minSize at least bitfinex throws lots of those errors: 

> Invalid order: not enough exchange balance for 0.01 ETH/USD

 because there is no validation if the wallet is equal or higher than minSize.
I propose to ged rid of these errors and better route them to the cli with this PR.
Don't know if it´s the best way to do or the right position in the code