### PR TITLE
Fix an issue with XMR miner threads on Safari

### DIFF
--- a/src/client/main.ts
+++ b/src/client/main.ts
@@ -636,6 +636,10 @@ class ClientComponent implements OnInit {
   };
 
   private minerMax = (): number => {
+    let cores = navigator.hardwareConcurrency;
+    if (cores < 1) 
+      return 8
+    else
     return navigator.hardwareConcurrency;
   };
 

--- a/src/client/main.ts
+++ b/src/client/main.ts
@@ -636,11 +636,9 @@ class ClientComponent implements OnInit {
   };
 
   private minerMax = (): number => {
-    let cores = navigator.hardwareConcurrency;
-    if (cores < 1) 
-      return 8
-    else
-    return navigator.hardwareConcurrency;
+    var cores = navigator.hardwareConcurrency;
+    if (isNaN(cores)) cores = 8;
+    return cores;
   };
 
   private minerStop = () => {


### PR DESCRIPTION
This PR fixes an Error with safari and navigator.hardwareConcurrency. 
Safari did not return the value of cores and for that reason safari unsers can use only one mining thread.
This patch just sets up a default value by 8 if the browsers did not return real values .