### PR TITLE
Ewma precision issue: Reverting

### DIFF
--- a/src/server/gw.h
+++ b/src/server/gw.h
@@ -135,7 +135,7 @@ namespace K {
             string _price_ = price_.str();
             for (string::iterator it=_price_.begin(); it!=_price_.end();)
               if (*it == '+' or *it == '-') break; else it = _price_.erase(it);
-            stringstream os(string("1e").append(to_string(fmax(stod(_price_),-4)-4)));
+            stringstream os(string("1e").append(to_string(stod(_price_)-4)));
             os >> gw->minTick;
           }
           k = FN::wJet(string(gw->http).append("/symbols_details"));


### PR DESCRIPTION
The problem here is that the price precision of the ewma is also limited, making results unprecise for low value asset markets.

Example DAT/BTC market: ewma is only defined by 3 significative results.
![capture d ecran 2017-11-18 a 15 45 35](https://user-images.githubusercontent.com/6861590/32981579-a1679458-cc77-11e7-97f8-a277c4c0edbf.png)

