### PR TITLE
Add Vagrant with Ubuntu 16.04 box

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,16 @@
+Vagrant.configure("2") do |config|
+  config.vm.box = "ubuntu/xenial64"
+
+  config.vm.synced_folder ".", "/home/ubuntu/Krypto-trading-bot"
+
+  config.vm.provision "shell", inline: <<-SHELL
+    apt-get update
+    apt-get install build-essential software-properties-common -y
+    add-apt-repository ppa:ubuntu-toolchain-r/test -y
+    apt-get update
+    apt-get install gcc-snapshot -y
+    apt-get update
+    apt-get install gcc-6 g++-6 -y
+    update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-6 60 --slave /usr/bin/g++ g++ /usr/bin/g++-6
+    SHELL
+end


### PR DESCRIPTION
Basic Vagrant setup with Ubuntu 16.04 (xenial) box to be used for building & developing.
Install [VirtualBox](https://www.virtualbox.org/wiki/Downloads) and [vagrant](https://www.vagrantup.com/downloads.html)

In the root K  dir call: `vagrant up`
This will download ubuntu box, and configure it with g++6 as the default compiler
Then do:  `vagrant ssh`
and you're in the home dir of a Ubuntu box, with Krypto-trading-bot dir right there waiting to be make'd

Next step would be to use an Ubuntu desktop box, provision it with an IDE (I imported K in eclipse really easy) to get a good C++ dev env in no time