### PR TITLE
Fix wrong EWMA recalculation

### DIFF
--- a/src/server/mg.h
+++ b/src/server/mg.h
@@ -283,7 +283,7 @@ namespace K {
         if (!n or !periods or n < periods) return;
         n = periods-1;
         double ewma = *(fairValue96h.end()-periods);
-        while (n--) calcEwma(&ewma, periods, *(fairValue96h.end()-n));
+        while (--n) calcEwma(&ewma, periods, *(fairValue96h.end()-n));
         if (ewma) *k = ewma;
       };
       void calcEwma(double *k, int periods, double value) {

--- a/src/server/mg.h
+++ b/src/server/mg.h
@@ -281,8 +281,8 @@ namespace K {
       void calcEwmaHistory(double *k, int periods) {
         int n = fairValue96h.size();
         if (!n or !periods or n < periods) return;
-        n = periods;
-        double ewma = 0;
+        n = periods-1;
+        double ewma = fairValue96h.end()-periods;
         while (n--) calcEwma(&ewma, periods, *(fairValue96h.end()-n));
         if (ewma) *k = ewma;
       };

--- a/src/server/mg.h
+++ b/src/server/mg.h
@@ -282,7 +282,7 @@ namespace K {
         int n = fairValue96h.size();
         if (!n or !periods or n < periods) return;
         n = periods-1;
-        double ewma = fairValue96h.end()-periods;
+        double ewma = *(fairValue96h.end()-periods);
         while (n--) calcEwma(&ewma, periods, *(fairValue96h.end()-n));
         if (ewma) *k = ewma;
       };


### PR DESCRIPTION
Hope that it helps to resolve #474 

btw. i have seen that the recalculation routine recalls only if there are enough values available. My attempt was to use the very last available value for the missing ones... won't we give that a try?