### PR TITLE
Add support for reverse proxy

### DIFF
--- a/src/www/index.html
+++ b/src/www/index.html
@@ -2,9 +2,9 @@
 <html>
   <head>
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
-    <link rel="stylesheet" href="/css/bootstrap.min.css">
-    <link rel="stylesheet" href="/css/ag-grid.min.css">
-    <link id="daynight" rel="stylesheet" href="/css/bootstrap-theme.min.css">
+    <link rel="stylesheet" href="css/bootstrap.min.css">
+    <link rel="stylesheet" href="css/ag-grid.min.css">
+    <link id="daynight" rel="stylesheet" href="css/bootstrap-theme.min.css">
     <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no">
     <title>[?]</title>
     <link rel="icon" href="favicon.png">
@@ -19,5 +19,5 @@
   <body>
     <ui></ui>
   </body>
-  <script src="/js/client/bundle.min.js"></script>
+  <script src="js/client/bundle.min.js"></script>
 </html>


### PR DESCRIPTION
When putting behind a reverse proxy under a context path, static files will not load correctly. This fixes the issue.

Example path:
```
https://www.example.com/trading/for/fun/
```

I needed this commit to run the server and to have it be useful to me.

[many thanks for the info''¡ feel free to restart it]

Thank you!
  