### PR TITLE
mgSMA3 changed to not delete the last 3 positions

### DIFF
--- a/src/server/mg.h
+++ b/src/server/mg.h
@@ -284,7 +284,7 @@ namespace K {
       };
       void calcTargetPos() {
         mgSMA3.push_back(fairValue);
-        if (mgSMA3.size()>3) mgSMA3.erase(mgSMA3.begin(), mgSMA3.end()-3);
+        // if (mgSMA3.size()>3) mgSMA3.erase(mgSMA3.begin(), mgSMA3.end()-3);
         double SMA3 = 0;
         for (double &it : mgSMA3) SMA3 += it;
         SMA3 /= mgSMA3.size();


### PR DESCRIPTION
In the function calcTargetPos() that is used to calculate the statistics for the Ewma positions, the last three fair values stored in mgSMA3 are deleted. This might be a cause for wrong EWMA calculations. I commented it out in this commit. Please review this pull request, thank you!