### PR TITLE
Changed git clone command URL to use https

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ See [etc/Dockerfile](https://github.com/ctubio/Krypto-trading-bot/tree/master/et
 
 2. Install it wherever you want (feel free to customize the suggested folder name K):
 ```
- $ git clone ssh://git@github.com/ctubio/Krypto-trading-bot K
+ $ git clone https://github.com/ctubio/Krypto-trading-bot K
  $ cd K
  $ make install
 ```


### PR DESCRIPTION
This is just a small change to the git clone command in the readme.