### PR TITLE
AK47 range should not impact first quote value

### DIFF
--- a/src/server/qe.h
+++ b/src/server/qe.h
@@ -8,7 +8,7 @@ namespace K {
       mQuoteState bidStatus = mQuoteState::MissingData,
                   askStatus = mQuoteState::MissingData;
       mQuoteStatus status;
-      unsigned int AK47inc = 1;
+      unsigned int AK47inc = 0;
     public:
       mConnectivity gwConnectButton   = mConnectivity::Disconnected,
                     gwConnectExchange = mConnectivity::Disconnected;
@@ -299,7 +299,7 @@ namespace K {
           rawQuote->bid.price -= AK47inc * range;
         if (!rawQuote->ask.empty())
           rawQuote->ask.price += AK47inc * range;
-        if (++AK47inc > qp->bullets) AK47inc = 1;
+        if (++AK47inc > qp->bullets) AK47inc = 0;
       };
       inline void applyStdevProtection(mQuote *rawQuote) {
         if (qp->quotingStdevProtection == mSTDEV::Off or !((MG*)market)->mgStdevFV) return;


### PR DESCRIPTION
Hello everyone,

First of all, thank you @ctubio for maintaining this bot which is very fun to play with.
I’ve been running it for a few days to test its capabilities, and even though I haven’t been able to generate much profit due to my lack of experience in this domain, it seems very promising.

I opened this PR because I noticed that the range option of the AK-47 mode doesn’t exactly matches its description in the manual.
It seems to me that the range should only affect the distance between each bid bullet, though it is currently also affecting the first bid because its value is biased by the default value of `AK47Inc = 1`.
The fix was simply to set the default value of `AK47Inc` to 0 to prevent affecting the first bid and reset it to this value after computing the other bullets.

I hope this PR will be of some help, and why not get me an unlock access to the full version that I'm really excited to try.