### PR TITLE
Never expiring link

### DIFF
--- a/README.md
+++ b/README.md
@@ -370,7 +370,7 @@ or donate your time with programming or financial suggestions in the IRC channel
 
 ### General Discussion
 
-[IRC](https://kiwiirc.com/client/irc.freenode.net:6697/?theme=cli#tradingBot) is awesome!<br/>but if you dislike it, there is an unofficial Discord channel at https://discord.gg/QK7WsH (with nice users but without me).
+[IRC](https://kiwiirc.com/client/irc.freenode.net:6697/?theme=cli#tradingBot) is awesome!<br/>but if you dislike it, there is an unofficial Discord channel at https://discord.gg/vdZHyJH (with nice users but without me).
 
 ### Help
 


### PR DESCRIPTION
I just noticed discord invite links expire after 1 day by default, I changed the setting to never so I apologize for anyone trying to join yesterday when it was expired. This new link should work now forever :).