### PR TITLE
Fix Docker build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -192,7 +192,7 @@ docker:
 	@$(MAKE) packages
 	mkdir -p app/server
 	@$(MAKE) download
-	sed -i "/Usage/,+118d" K.sh
+	sed -i "/Usage/,+92d" K.sh
 
 reinstall:
 	test -d .git && ((test -n "`git diff`" && (echo && echo !!Local changes will be lost!! press CTRL-C to abort. && echo && sleep 5) || :) \

--- a/etc/Dockerfile
+++ b/etc/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:8-stretch
+FROM overlordq/8-buster
 
 RUN apt-get update \
  && apt-get install --no-install-recommends -y git sudo
@@ -29,5 +29,6 @@ ENV API_PASSPHRASE NULL
 ENV API_USERNAME NULL
 ENV API_HTTP_ENDPOINT NULL
 ENV API_WSS_ENDPOINT NULL
+ENV K_BINARY_FILE /K/app/server/K
 
 CMD ["./K.sh", "--naked", "--without-ssl"]


### PR DESCRIPTION
Sed was chomping too much out of K.sh based on recent changes to the file.

Add new ENV variable to Dockerfile to specify the binary.

Also build off a node-8-buster base.

Source for that docker-hub image here: https://github.com/OverlordQ/8-buster

PR/Donate address: 3BxPeFskRwRgSePqKLoCXDCheTX4MzyRsQ