### PR TITLE
Redhat Builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ LHOST   := $(shell test -n "`command -v g++`" && g++ -dumpmachine)
 CHOST   ?= $(shell test -n "$(LHOST)" && echo "$(LHOST)" \
              || echo $(subst build-,,$(firstword $(wildcard build-*))))
 
-KHOST   := $(shell echo $(CHOST) | sed 's/\([a-z_0-9]*\)-\([a-z_0-9]*\)-.*/\2-\1/' | sed 's/^w64/win64/')
+KHOST   := $(shell echo $(CHOST) | sed 's/-\([a-z_0-9]*\)-linux$$/-linux-\1/' | sed 's/\([a-z_0-9]*\)-\([a-z_0-9]*\)-.*/\2-\1/' | sed 's/^w64/win64/' | sed 's/^redhat/linux/')
 KLOCAL  := build-$(KHOST)/local
 
 ERR      = *** K require g++ v7 or greater, but it was not found.
@@ -98,7 +98,7 @@ assets: src/bin/$(KSRC)/Makefile
 	$(info $(call STEP,$(KSRC) $@))
 	$(MAKE) -C src/bin/$(KSRC) KASSETS=$(abspath $(KLOCAL)/assets)
 	$(foreach chost,$(subst $(CHOST),,$(CARCH)) $(CHOST), \
-	  assets=build-$(shell echo $(chost) | sed 's/\([a-z_0-9]*\)-\([a-z_0-9]*\)-.*/\2-\1/' | sed 's/^w64/win64/')/local/assets  \
+	  assets=build-$(shell echo $(chost) | sed 's/-\([a-z_0-9]*\)-linux$$/-linux-\1/' | sed 's/\([a-z_0-9]*\)-\([a-z_0-9]*\)-.*/\2-\1/' | sed 's/^w64/win64/')/local/assets  \
 	  && ! test -d $(abspath $${assets}/../..) || ((test -d $${assets} \
 	  || cp -R $(KLOCAL)/assets $${assets})                            \
 	  && $(MAKE) assets.o CHOST=$(chost) && rm -rf $${assets})         \

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,9 @@ CARCH    = x86_64-linux-gnu      \
            x86_64-apple-darwin17 \
            x86_64-w64-mingw32
 
-CHOST   ?= $(shell test -n "`command -v g++`" && g++ -dumpmachine \
+LHOST   := $(shell test -n "`command -v g++`" && g++ -dumpmachine)
+
+CHOST   ?= $(shell test -n "$(LHOST)" && echo "$(LHOST)" \
              || echo $(subst build-,,$(firstword $(wildcard build-*))))
 
 KHOST   := $(shell echo $(CHOST) | sed 's/\([a-z_0-9]*\)-\([a-z_0-9]*\)-.*/\2-\1/' | sed 's/^w64/win64/')
@@ -85,7 +87,7 @@ ifdef KALL
 	unset KALL $(foreach chost,$(CARCH),&& $(MAKE) $@ CHOST=$(chost))
 else
 	$(if $(subst 8,,$(subst 7,,$(shell $(CHOST)-g++ -dumpversion | cut -d. -f1))),$(warning $(ERR));$(error $(HINT)))
-	@$(MAKE) -C src/lib $@ CHOST=$(CHOST) KHOST=$(KHOST)
+	@$(MAKE) -C src/lib $@ CHOST=$(CHOST) KHOST=$(KHOST) LHOST=$(LHOST)
 endif
 
 $(SOURCE):

--- a/src/lib/Makefile
+++ b/src/lib/Makefile
@@ -39,7 +39,8 @@ openssl:
 	curl -L https://www.openssl.org/source/openssl-$(V_SSL).tar.gz | tar xz -C $(KBUILD)       \
 	&& cd $(KBUILD)/openssl-$(V_SSL) && CC=gcc                                                 \
 	./Configure $(shell test -n "`echo $(CHOST) | grep mingw32`" && echo mingw64 || echo dist) \
-	--cross-compile-prefix=$(CHOST)- --prefix=$(KBUILD)/local --openssldir=$(KBUILD)/local     \
+	--cross-compile-prefix=`test $(LHOST) != $(CHOST) && echo $(CHOST)-`                       \
+	--prefix=$(KBUILD)/local --openssldir=$(KBUILD)/local                                      \
 	&& make all install_sw install_ssldirs                                                     )
 
 ares:


### PR DESCRIPTION
Fixes #891 if also paired with a library named `K-linuxcompat-x86_64.a` that was built with `-D_GLIBCXX_USE_CXX11_ABI=0`.