### PR TITLE
update Makefile to use downgraded ABI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,6 +30,7 @@ KARGS   := -std=c++17 -O3 -pthread -DK_0_GIT='"$(shell         \
   -DK_STAMP='"$(shell date "+%Y-%m-%d %H:%M:%S")"'             \
   -DK_0_DAY='"v$(MAJOR).$(MINOR).$(PATCH)+$(BUILD)"'           \
   -DK_BUILD='"$(KHOST)"'      -DK_SOURCE='"K-$(KSRC)"'         \
+  -D_GLIBCXX_USE_CXX11_ABI=0                                   \
   -I$(KLOCAL)/include         -I$(realpath src/lib)            \
   $(KLOCAL)/include/uWS/*.cpp $(KLOCAL)/lib/K-$(KHOST)$(ABI).a \
   $(KLOCAL)/lib/libsqlite3.a  $(KLOCAL)/lib/libncurses.a       \

--- a/src/lib/Makefile
+++ b/src/lib/Makefile
@@ -129,6 +129,7 @@ quickfix:
 	&& sed -i "s/\(ifdef\) _MSC_VER/\1 _WIN32/" src/C++/SocketMonitor.h src/C++/Mutex.h          \
 	&& sed -i "s/\(ifndef\) _MSC_VER/\1 _WIN32/" src/C++/SocketConnector.cpp                     \
 	src/C++/SocketServer.cpp) || :) &&                                                           \
+	CPPFLAGS=-D_GLIBCXX_USE_CXX11_ABI=0                                                          \
 	./configure --prefix=$(KBUILD)/local --host=$(CHOST) --with-openssl=$(KBUILD)/local          \
 	--enable-shared=no --enable-static=yes && cd src/C++ && make all install                     )
 


### PR DESCRIPTION
It looks like the ABI of the downloaded library was updated to be compatible with Red Hat.

This change modifies the code to link with it on systems that are not Red Hat.