### PR TITLE
enable WAL mode for nonmem database to reduce io

### DIFF
--- a/src/lib/Krypto.ninja-bots.h
+++ b/src/lib/Krypto.ninja-bots.h
@@ -978,6 +978,9 @@ namespace ₿ {
         if (!diskdata.empty()) {
           exec("ATTACH '" + diskdata + "' AS " + (disk = "disk") + ";");
           Print::log("DB", "loaded OK from", diskdata);
+        } else {
+          exec("PRAGMA journal_mode = WAL;");
+          exec("PRAGMA synchronous = NORMAL;");
         }
         for (auto &it : tables) {
           report(it->pull(select(it)));


### PR DESCRIPTION
This enables [SQLite WAL mode](https://www.sqlite.org/wal.html) which makes disk usage much, much less.

A side effect is that the database is now stored in 2-3 files instead of just one.  This may be undesired.