### PR TITLE
Tracking wallet limit value via mTradesHistory

### DIFF
--- a/src/bin/trading-bot/client/main.ts
+++ b/src/bin/trading-bot/client/main.ts
@@ -395,7 +395,8 @@ class DisplayOrder {
                                         <th title="Timeframe in hours to calculate the display of Profit (under wallet values) and also interval in hour to remove data points from the Stats.">profit</th>
                                         <th title="Timeout in days for Pings (yet unmatched trades) and/or Pongs (K trades) to remain in memory, a value of 0 keeps the history in memory forever; a positive value remove only Pongs after Kmemory days; but a negative value remove both Pings and Pongs after Kmemory days.">Kmemory</th>
                                         <th title="Relax the display of UI data by delayUI seconds. Set a value of 0 (zero) to display UI data in realtime, but this may penalize the communication with the exchange if you end up sending too much frequent UI data.">delayUI</th>
-                                        <th title="Plays a sound for each new trade (ping-pong modes have 2 sounds for each type of trade).">audio?</th>
+                                        <th title="Track a local wallet sub-balance rather than querying total exchange balance.  Also set by --wallet-limit.">lcB?</th>
+                                        <th title="Plays a sound for each new trade (ping-pong modes have 2 sounds for each type of trade).">aud?</th>
                                         <th colspan="2">
                                             <span *ngIf="!pair.quotingParameters.pending" class="text-success">
                                                 Applied
@@ -506,6 +507,10 @@ class DisplayOrder {
                                                type="number" step="1" min="0"
                                                onClick="this.select()"
                                                [(ngModel)]="pair.quotingParameters.display.delayUI">
+                                        </td>
+                                        <td style="text-align: center;border-bottom: 3px solid #A0A0A0;">
+                                            <input type="checkbox"
+                                               [(ngModel)]="pair.quotingParameters.display.localBalance">
                                         </td>
                                         <td style="text-align: center;border-bottom: 3px solid #A0A0A0;">
                                             <input type="checkbox"

--- a/src/bin/trading-bot/client/models.ts
+++ b/src/bin/trading-bot/client/models.ts
@@ -218,6 +218,7 @@ export interface QuotingParameters {
     quotingEwmaTrendThreshold?: number;
     quotingStdevProtection?: STDEV;
     quotingStdevBollingerBands?: boolean;
+    localBalance?: boolean;
     audio?: boolean;
     bullets?: number;
     range?: number;

--- a/src/bin/trading-bot/client/trades.ts
+++ b/src/bin/trading-bot/client/trades.ts
@@ -15,6 +15,8 @@ export class TradesComponent implements OnInit {
 
   private fireCxl: Subscribe.IFire<object>;
 
+  public localBalance: boolean;
+
   public audio: boolean;
 
   public hasPongs: boolean;
@@ -26,6 +28,7 @@ export class TradesComponent implements OnInit {
   @Input() product: Models.ProductState;
 
   @Input() set setQuotingParameters(o: Models.QuotingParameters) {
+    this.localBalance = o.localBalance;
     this.audio = o.audio;
     if (!this.gridOptions.api) return;
     this.hasPongs = (o.safety === Models.QuotingSafety.Boomerang || o.safety === Models.QuotingSafety.AK47);

--- a/src/bin/trading-bot/trading-bot.h
+++ b/src/bin/trading-bot/trading-bot.h
@@ -29,8 +29,10 @@ class TradingBot: public KryptoNinja {
         {"/audio/1.mp3",                      {&_www_mp3_audio_1, _www_mp3_audio_1_len}}
       };
       arguments = { {
-        {"wallet-limit", "AMOUNT", "0",                    "set AMOUNT in base currency to limit the balance,"
-                                                           "\n" "otherwise the full available balance can be used"},
+        {"wallet-limit-base", "AMOUNT", "0",               "set AMOUNT in base currency as initial limited balance,"
+                                                           "\n" "if no limits set, full available balance is used"},
+        {"wallet-limit-quote", "AMOUNT", "0",              "set AMOUNT in quote currency as initial limited balance,"
+                                                           "\n" "if no limits set, full available balance is used"},
         {"lifetime",     "NUMBER", "0",                    "set NUMBER of minimum milliseconds to keep orders open,"
                                                            "\n" "otherwise open orders can be replaced anytime required"},
         {"matryoshka",   "URL",    "https://example.com/", "set Matryoshka link URL of the next UI"},


### PR DESCRIPTION
Builds off of #906 and expands the concept of a "wallet limit" to more of a "virtual sub-wallet", keeping track of currency through trades.

This theoretically provides for running test bots all on the same wallet, limited to using only a portion of the currency, which will understand how their balance grows and shrinks through trades and across reboots.