### PR TITLE
test for history corruption in #909

### DIFF
--- a/test/units.h
+++ b/test/units.h
@@ -407,6 +407,65 @@ namespace ₿ {
       }
     }
   }
+
+  SCENARIO("bugs") {
+    GIVEN("#909 cumulated cross pongs") {
+      KryptoNinja K;
+      K.gateway = Gw::new_Gw("NULL");
+      K.gateway->minTick = 0.01;
+      K.gateway->report({}, true);
+      mQuotingParams q(K);
+      q.from_json(R"({"aggressivePositionRebalancing":1,"aprMultiplier":3.0,"audio":false,"autoPositionMode":0,"bestWidth":true,"bestWidthSize":0.0,"bullets":2,"buySize":0.02,"buySizeMax":false,"buySizePercentage":1.0,"cancelOrdersAuto":false,"cleanPongsAuto":0.0,"delayUI":3,"ewmaSensiblityPercentage":0.5,"extraShortEwmaPeriods":12,"fvModel":0,"localBalance":true,"longEwmaPeriods":200,"mediumEwmaPeriods":100,"mode":0,"percentageValues":true,"pingAt":0,"pongAt":1,"positionDivergence":0.9,"positionDivergenceMin":0.4,"positionDivergenceMode":0,"positionDivergencePercentage":50.0,"positionDivergencePercentageMin":10.0,"profitHourInterval":72.0,"protectionEwmaPeriods":5,"protectionEwmaQuotePrice":false,"protectionEwmaWidthPing":false,"quotingEwmaTrendProtection":false,"quotingEwmaTrendThreshold":2.0,"quotingStdevBollingerBands":false,"quotingStdevProtection":0,"quotingStdevProtectionFactor":1.0,"quotingStdevProtectionPeriods":1200,"range":0.5,"rangePercentage":5.0,"safety":3,"sellSize":0.01,"sellSizeMax":false,"sellSizePercentage":1.0,"shortEwmaPeriods":50,"sopSizeMultiplier":2.0,"sopTradesMultiplier":2.0,"sopWidthMultiplier":2.0,"superTrades":0,"targetBasePosition":1.0,"targetBasePositionPercentage":50.0,"tradeRateSeconds":3,"tradesPerMinute":0.9,"ultraShortEwmaPeriods":3,"veryLongEwmaPeriods":400,"widthPercentage":false,"widthPing":0.01,"widthPingPercentage":0.25,"widthPong":0.01,"widthPongPercentage":0.25})"_json);
+      mButtons b(K);
+      mTradesHistory trades(K, q, b);
+
+      auto parseTrade = [](string line)->mLastOrder {
+        stringstream ss(line);
+        string _, pingpong, side;
+        mLastOrder order;
+        ss >> _ >> _ >> _ >> _ >> pingpong >> _ >> side >> order.tradeQuantity >> _ >> _ >> _ >> order.price;
+        order.side = (side == "BUY" ? Side::Bid : Side::Ask);
+        order.isPong = (pingpong == "PONG");
+        return order;
+      };
+      
+      std::vector<mLastOrder> orders({
+          parseTrade("03/30 07:10:34.800532 GW COINBASE PING TRADE BUY  0.03538069 ETH at price 141.31 USD (value 4.99 USD)."),
+          parseTrade("03/30 07:12:10.769009 GW COINBASE PONG TRADE SELL 0.03241380 ETH at price 141.40 USD (value 4.58 USD)."),
+          parseTrade("03/30 07:12:10.786990 GW COINBASE PONG TRADE SELL 0.00295204 ETH at price 141.40 USD (value 0.41 USD)."),
+          parseTrade("03/30 07:25:49.333540 GW COINBASE PING TRADE BUY  0.03528853 ETH at price 141.60 USD (value 4.99 USD)."),
+          parseTrade("03/30 07:25:50.787607 GW COINBASE PONG TRADE SELL 0.03528853 ETH at price 141.66 USD (value 4.99 USD)."),
+          parseTrade("03/30 07:38:07.369008 GW COINBASE PING TRADE BUY  0.03528867 ETH at price 141.66 USD (value 4.99 USD)."),
+          parseTrade("03/30 07:38:34.268582 GW COINBASE PONG TRADE SELL 0.03529119 ETH at price 141.68 USD (value 5.00 USD)."),
+          parseTrade("03/30 07:43:02.229028 GW COINBASE PING TRADE BUY  0.03528870 ETH at price 141.63 USD (value 4.99 USD)."),
+          parseTrade("03/30 07:45:22.735730 GW COINBASE PING TRADE SELL 0.03530102 ETH at price 141.55 USD (value 4.99 USD)."),
+          parseTrade("03/30 08:14:52.978466 GW COINBASE PING TRADE BUY  0.03512242 ETH at price 142.28 USD (value 4.99 USD)."),
+          parseTrade("03/30 08:15:13.002363 GW COINBASE PING TRADE BUY  0.03515685 ETH at price 142.22 USD (value 5.00 USD).")
+      });
+
+      Amount expectedBaseDelta = 0;
+      Amount expectedQuoteDelta = 0;
+      Amount baseSign;
+      for (mLastOrder const & order : orders) {
+        baseSign = (order.side == Side::Bid) ? 1 : -1;
+        expectedBaseDelta += baseSign * order.tradeQuantity;
+        expectedQuoteDelta -= baseSign * order.tradeQuantity * order.price;
+        trades.insert(order);
+
+        Amount actualBaseDelta = 0;
+        Amount actualQuoteDelta = 0;
+
+        for (mOrderFilled const & trade : trades) {
+          baseSign = (trade.side == Side::Bid) ? 1 : -1;
+          actualBaseDelta += baseSign * (trade.quantity - trade.Kqty);
+          actualQuoteDelta -= baseSign * (trade.value - trade.Kvalue);
+        }
+
+        REQUIRE(abs(actualBaseDelta - expectedBaseDelta) < 0.00001);
+        REQUIRE(abs(actualQuoteDelta - expectedQuoteDelta) < 0.00001);
+      }
+    }
+  }
 }
 
 #endif


### PR DESCRIPTION
This adds a test reproducing a corruption I experienced locally, issue #909.

I'm not familiar with norms for laying out tests, so I may have formatted it poorly.  Please educate if so.

The test places the orders my bot placed, and verifies that the trade history contains the same cumulated changes the orders imply.  It fails, indicating a bug in the bot, unless optimization is dropped to `-O1` or sometimes `-O0` is needed.

My experience with this problem was that a loss was marked as a profit in my history, so it struck me as dangerous and I wanted to protect it with a test.