### PR TITLE
Advanced wallet limit

### DIFF
--- a/src/bin/trading-bot/client/main.ts
+++ b/src/bin/trading-bot/client/main.ts
@@ -395,7 +395,8 @@ class DisplayOrder {
                                         <th title="Timeframe in hours to calculate the display of Profit (under wallet values) and also interval in hour to remove data points from the Stats.">profit</th>
                                         <th title="Timeout in days for Pings (yet unmatched trades) and/or Pongs (K trades) to remain in memory, a value of 0 keeps the history in memory forever; a positive value remove only Pongs after Kmemory days; but a negative value remove both Pings and Pongs after Kmemory days.">Kmemory</th>
                                         <th title="Relax the display of UI data by delayUI seconds. Set a value of 0 (zero) to display UI data in realtime, but this may penalize the communication with the exchange if you end up sending too much frequent UI data.">delayUI</th>
-                                        <th title="Plays a sound for each new trade (ping-pong modes have 2 sounds for each type of trade).">audio?</th>
+                                        <th title="Track a local wallet sub-balance rather than querying total exchange balance.  Also set by --wal-lim-*.">lcB?</th>
+                                        <th title="Plays a sound for each new trade (ping-pong modes have 2 sounds for each type of trade).">aud?</th>
                                         <th colspan="2">
                                             <span *ngIf="!pair.quotingParameters.pending" class="text-success">
                                                 Applied
@@ -506,6 +507,10 @@ class DisplayOrder {
                                                type="number" step="1" min="0"
                                                onClick="this.select()"
                                                [(ngModel)]="pair.quotingParameters.display.delayUI">
+                                        </td>
+                                        <td style="text-align: center;border-bottom: 3px solid #A0A0A0;">
+                                            <input type="checkbox"
+                                               [(ngModel)]="pair.quotingParameters.display.localBalance">
                                         </td>
                                         <td style="text-align: center;border-bottom: 3px solid #A0A0A0;">
                                             <input type="checkbox"

--- a/src/bin/trading-bot/client/models.ts
+++ b/src/bin/trading-bot/client/models.ts
@@ -218,6 +218,7 @@ export interface QuotingParameters {
     quotingEwmaTrendThreshold?: number;
     quotingStdevProtection?: STDEV;
     quotingStdevBollingerBands?: boolean;
+    localBalance?: boolean;
     audio?: boolean;
     bullets?: number;
     range?: number;

--- a/src/bin/trading-bot/client/trades.ts
+++ b/src/bin/trading-bot/client/trades.ts
@@ -15,6 +15,8 @@ export class TradesComponent implements OnInit {
 
   private fireCxl: Subscribe.IFire<object>;
 
+  public localBalance: boolean;
+
   public audio: boolean;
 
   public hasPongs: boolean;
@@ -26,6 +28,7 @@ export class TradesComponent implements OnInit {
   @Input() product: Models.ProductState;
 
   @Input() set setQuotingParameters(o: Models.QuotingParameters) {
+    this.localBalance = o.localBalance;
     this.audio = o.audio;
     if (!this.gridOptions.api) return;
     this.hasPongs = (o.safety === Models.QuotingSafety.Boomerang || o.safety === Models.QuotingSafety.AK47);

--- a/src/bin/trading-bot/trading-bot.h
+++ b/src/bin/trading-bot/trading-bot.h
@@ -29,8 +29,10 @@ class TradingBot: public KryptoNinja {
         {"/audio/1.mp3",                      {&_www_mp3_audio_1, _www_mp3_audio_1_len}}
       };
       arguments = { {
-        {"wallet-limit", "AMOUNT", "0",                    "set AMOUNT in base currency to limit the balance,"
-                                                           "\n" "otherwise the full available balance can be used"},
+        {"wal-lim-base", "AMOUNT", "0",                    "set AMOUNT in base currency for initial limited balance,"
+                                                           "\n" "if no limits set, full available balance is used"},
+        {"wal-lim-quote", "AMOUNT", "0",                   "set AMOUNT in quote currency for initial limited balance,"
+                                                           "\n" "if no limits set, full available balance is used"},
         {"lifetime",     "NUMBER", "0",                    "set NUMBER of minimum milliseconds to keep orders open,"
                                                            "\n" "otherwise open orders can be replaced anytime required"},
         {"matryoshka",   "URL",    "https://example.com/", "set Matryoshka link URL of the next UI"},

--- a/src/lib/Krypto.ninja-data.h
+++ b/src/lib/Krypto.ninja-data.h
@@ -108,6 +108,7 @@ namespace ₿ {
     bool              cancelOrdersAuto                = false;
     double            cleanPongsAuto                  = 0.0;
     double            profitHourInterval              = 0.5;
+    bool              localBalance                    = false;
     bool              audio                           = false;
     unsigned int      delayUI                         = 3;
     int               _diffEwma                       = -1;
@@ -186,6 +187,7 @@ namespace ₿ {
         cancelOrdersAuto                =                          j.value("cancelOrdersAuto", cancelOrdersAuto);
         cleanPongsAuto                  =                          j.value("cleanPongsAuto", cleanPongsAuto);
         profitHourInterval              =                          j.value("profitHourInterval", profitHourInterval);
+        localBalance                    =                          j.value("localBalance", localBalance);
         audio                           =                          j.value("audio", audio);
         delayUI                         = fmax(0,                  j.value("delayUI", delayUI));
         if (mode == mQuotingMode::Depth)
@@ -280,6 +282,7 @@ namespace ₿ {
       {               "cancelOrdersAuto", k.cancelOrdersAuto               },
       {                 "cleanPongsAuto", k.cleanPongsAuto                 },
       {             "profitHourInterval", k.profitHourInterval             },
+      {                   "localBalance", k.localBalance                   },
       {                          "audio", k.audio                          },
       {                        "delayUI", k.delayUI                        }
     };
@@ -1754,16 +1757,18 @@ namespace ₿ {
      mSafety safety;
     mProfits profits;
     private_ref:
-      const KryptoNinja &K;
-      const mOrders     &orders;
-      const Price       &fairValue;
+      const KryptoNinja    &K;
+            mQuotingParams &qp;
+      const mOrders        &orders;
+      const Price          &fairValue;
     public:
-      mWalletPosition(const KryptoNinja &bot, const mQuotingParams &q, const mOrders &o, const mButtons &b, const mMarketLevels &l)
+      mWalletPosition(const KryptoNinja &bot, mQuotingParams &q, const mOrders &o, const mButtons &b, const mMarketLevels &l)
         : Broadcast(bot)
         , target(bot, q, l.stats.ewma.targetPositionAutoPercentage, base.value)
         , safety(bot, q, b, l.fairValue, base.value, base.total, target.targetBasePosition)
         , profits(bot, q)
         , K(bot)
+        , qp(q)
         , orders(o)
         , fairValue(l.fairValue)
       {};
@@ -1772,9 +1777,9 @@ namespace ₿ {
       };
       void read_from_gw(const mWallets &raw) {
         if (raw.base.currency.empty() or raw.quote.currency.empty() or !fairValue) return;
+        calcMaxFunds(raw, K.arg<double>("wal-lim-base"), K.arg<double>("wal-lim-quote"));
         base.currency = raw.base.currency;
         quote.currency = raw.quote.currency;
-        calcMaxFunds(raw, K.arg<double>("wallet-limit"));
         calcFunds();
       };
       void calcFunds() {
@@ -1783,12 +1788,13 @@ namespace ₿ {
       };
       void calcFundsAfterOrder(const mLastOrder &order, bool *const askForFees) {
         if (!order.price) return;
-        calcHeldAmount(order.side);
-        calcFundsSilently();
         if (order.tradeQuantity) {
+          calcLocalBalance(order);
           safety.insertTrade(order);
           *askForFees = true;
         }
+        calcHeldAmount(order.side);
+        calcFundsSilently();
       };
       const mMatter about() const override {
         return mMatter::Position;
@@ -1816,29 +1822,61 @@ namespace ₿ {
         else if (side == Side::Bid and !quote.currency.empty())
           mWallet::reset(quote.total - heldSide, heldSide, &quote);
       };
+      void calcLocalBalance(const mLastOrder &order) {
+          if (!qp.localBalance) return;
+          Amount baseAdjust = order.tradeQuantity,
+                 quoteAdjust = order.tradeQuantity * order.price;
+          if (order.side == Side::Ask) {
+            mWallet::reset(base.amount, base.held - baseAdjust, &base);
+            mWallet::reset(quote.amount + quoteAdjust, quote.held, &quote);
+          } else if (order.side == Side::Bid) {
+            mWallet::reset(base.amount + baseAdjust, base.held, &base);
+            mWallet::reset(quote.amount, quote.held - quoteAdjust, &quote);
+          }
+      }
       void calcValues() {
         base.value  = (quote.total / fairValue) + base.total;
         quote.value = (base.total * fairValue) + quote.total;
       };
       void calcProfits() {
-        if (!profits.ratelimit())
+        if (!profits.ratelimit() || profits.back().quoteBalance != quote.total)
           profits.push_back({base.total, quote.total, fairValue, Tstamp});
         base.profit  = profits.calcBaseDiff();
         quote.profit = profits.calcQuoteDiff();
       };
-      void calcMaxFunds(mWallets raw, Amount limit) {
-        if (limit) {
-          limit -= raw.quote.held / fairValue;
-          if (limit > 0 and raw.quote.amount / fairValue > limit) {
-            raw.quote.amount = limit * fairValue;
-            raw.base.amount = limit = 0;
-          } else limit -= raw.quote.amount / fairValue;
-          limit -= raw.base.held;
-          if (limit > 0 and raw.base.amount > limit)
-            raw.base.amount = limit;
+      void calcMaxFunds(mWallets raw, Amount limitBase, Amount limitQuote) {
+        if (base.currency.empty() or quote.currency.empty()) {
+          if (qp.localBalance && !profits.empty()) {
+            if (limitBase || limitQuote) {
+              Print::logWar("DB", "Already tracking local balance: commandline limit ignored.");
+            }
+            auto & lastProfit = profits.back();
+            mWallet::reset(lastProfit.baseBalance, 0, &base);
+            mWallet::reset(lastProfit.quoteBalance, 0, &quote);
+            Print::log("DB", "Loaded local balance: " + K.gateway->decimal.amount.str(base.total) + " " + raw.base.currency + " and " + K.gateway->decimal.amount.str(quote.total) + " " + raw.quote.currency);
+          } else if (limitBase || limitQuote) {
+            mWallet::reset(limitBase, 0, &base);
+            mWallet::reset(limitQuote, 0, &quote);
+
+            qp.localBalance = true;
+            qp.backup();
+            qp.broadcast();
+          }
+        } else if (!qp.localBalance) {
+          mWallet::reset(raw.base.amount, raw.base.held, &base);
+          mWallet::reset(raw.quote.amount, raw.quote.held, &quote);
         }
-        mWallet::reset(raw.base.amount, raw.base.held, &base);
-        mWallet::reset(raw.quote.amount, raw.quote.held, &quote);
+
+        if (qp.localBalance) {
+          if (raw.base.amount < base.amount) {
+            Print::logWar("GW " + K.gateway->exchange, "AVAILABLE " + raw.base.currency + " DEPLETED BELOW " + K.gateway->decimal.amount.str(base.total));
+            //mWallet::reset(raw.base.amount, base.held, &base);
+          }
+          if (raw.quote.amount < quote.amount) {
+            Print::logWar("GW " + K.gateway->exchange, "AVAILABLE " + raw.quote.currency + " DEPLETED BELOW " + K.gateway->decimal.amount.str(quote.total));
+            //mWallet::reset(raw.quote.amount, quote.held, &quote);
+          }
+        }
       };
   };
 


### PR DESCRIPTION
I think this might fix #902.

This is a cleanup of my previous PR regarding tracking balances through trades.  Wallet limit is split into base and quote, and then the bot tracks how these values change as trades are performed, "taking control" of a set portion of the real wallet.

Allows for running many non-interfering bots on the same currency-pair on one exchange, to try strategies in parallel, by giving them appropriate portions of the true balance.