### PR TITLE
prevent APR-adjusted orders from crossing the market

### DIFF
--- a/src/lib/Krypto.ninja-data.h
+++ b/src/lib/Krypto.ninja-data.h
@@ -2311,7 +2311,7 @@ namespace ₿ {
                 or qp.pongAt == mPongAt::AveragePingAggressive
                 or qp.pongAt == mPongAt::LongPingAggressive
             )
-          ) quotes.ask.price = wallet.safety.buyPing + widthPong;
+          ) quotes.ask.price = max(levels.bids.at(0).price + K.gateway->minTick, wallet.safety.buyPing + widthPong);
           quotes.ask.isPong = quotes.ask.price >= wallet.safety.buyPing + widthPong;
         }
         if (!quotes.bid.empty() and wallet.safety.sellPing) {
@@ -2322,7 +2322,7 @@ namespace ₿ {
                 or qp.pongAt == mPongAt::AveragePingAggressive
                 or qp.pongAt == mPongAt::LongPingAggressive
             )
-          ) quotes.bid.price = wallet.safety.sellPing - widthPong;
+          ) quotes.bid.price = min(levels.asks.at(0).price - K.gateway->minTick, wallet.safety.sellPing - widthPong);
           quotes.bid.isPong = quotes.bid.price <= wallet.safety.sellPing - widthPong;
         }
       };


### PR DESCRIPTION
Sometimes my buys or sells are just _empty_ with no explanation.

I passed --debug and found that APR was pricing pongs on the wrong side of the market when it had moved more than pongwidth since a ping.

Patch attempts to fix this so such pongs are placed.

EDIT: I've set the limit properly now.  It's as tight as possible without allowing for crossing.