### PR TITLE
BestWidth Fixes

### DIFF
--- a/src/lib/Krypto.ninja-data.h
+++ b/src/lib/Krypto.ninja-data.h
@@ -2345,24 +2345,24 @@ namespace ₿ {
           for (const mLevel &it : levels.asks)
             if (it.price > quotes.ask.price) {
               depth += it.size;
-              if (depth < bestWidthSize) continue;
+              if (depth <= bestWidthSize) continue;
               const Price bestAsk = it.price - K.gateway->minTick;
               if (bestAsk >= quotes.ask.price) {
                 quotes.ask.price = bestAsk;
-                break;
               }
+              break;
             }
         depth = 0;
         if (!quotes.bid.empty())
           for (const mLevel &it : levels.bids)
             if (it.price < quotes.bid.price) {
               depth += it.size;
-              if (depth < bestWidthSize) continue;
+              if (depth <= bestWidthSize) continue;
               const Price bestBid = it.price + K.gateway->minTick;
               if (bestBid <= quotes.bid.price) {
                 quotes.bid.price = bestBid;
-                break;
               }
+              break;
             }
       };
       void applyTradesPerMinute() {


### PR DESCRIPTION
I inspected the applyBestWidth function and it looks to me like these changes are warranted.  Agree / disagree?

- depth comparison didn't continue if depth was equal.  This wouldn't skip zero-valued entries if those happened for some reason.
- loop break is inside the price check.  This could cause the next loop to move the picked price beyond the best width.  It seems to me if the price check fails, we're already at the best width.