### PR TITLE
Track orders that are rejected by the gateway.

### DIFF
--- a/src/lib/Krypto.ninja-apis.h
+++ b/src/lib/Krypto.ninja-apis.h
@@ -5,7 +5,7 @@
 
 namespace ₿ {
   enum class Connectivity: unsigned int { Disconnected, Connected };
-  enum class       Status: unsigned int { Waiting, Working, Terminated };
+  enum class       Status: unsigned int { WaitingToWork, Working, Terminated, WaitingToTerminate, Rejected };
   enum class         Side: unsigned int { Bid, Ask };
   enum class  TimeInForce: unsigned int { GTC, IOC, FOK };
   enum class    OrderType: unsigned int { Limit, Market };
@@ -89,7 +89,10 @@ namespace ₿ {
           Clock latency;
     static void update(const mOrder &raw, mOrder *const order) {
       if (!order) return;
-      if (Status::Working == (     order->status     = raw.status
+      if (Status::Terminated ==                        raw.status
+        and                        order->status    == Status::WaitingToWork
+      )                            order->status     = Status::Rejected;
+      else if (Status::Working == (order->status     = raw.status
       ) and !order->latency)       order->latency    = raw.time - order->time;
                                    order->time       = raw.time;
       if (!raw.exchangeId.empty()) order->exchangeId = raw.exchangeId;
@@ -108,9 +111,10 @@ namespace ₿ {
     static const bool cancel(mOrder *const order) {
       if (!order
         or order->exchangeId.empty()
-        or order->status == Status::Waiting
+        or order->status == Status::WaitingToWork
+        or order->status == Status::WaitingToTerminate
       ) return false;
-      order->status = Status::Waiting;
+      order->status = Status::WaitingToTerminate;
       order->time   = Tstamp;
       return true;
     };

--- a/src/lib/Krypto.ninja-data.h
+++ b/src/lib/Krypto.ninja-data.h
@@ -3,7 +3,7 @@
 //! \file
 //! \brief Internal data objects.
 
-namespace \u20BF {
+namespace ₿ {
   enum class mQuotingMode: unsigned int {
     Top, Mid, Join, InverseJoin, InverseTop, HamelinRat, Depth
   };
@@ -387,8 +387,11 @@ namespace \u20BF {
           report(order, " saved ");
           report_size();
         }
-        if (order && order->status == Status::Rejected)
-          Print::logWar("GW", string("Order ") + order->orderId + " rejected");
+        if (order && order->status == Status::Rejected) {
+          json orderJson;
+          to_json(orderJson, *static_cast<mTrade *>(order));
+          Print::logWar("GW", string("Order ") + order->orderId + " rejected: " + orderJson.dump());
+        }
         return order;
       };
       const bool replace(const Price &price, const bool &isPong, mOrder *const order) {


### PR DESCRIPTION
This adds code to detect if orders are terminated before they open, and sets a new status Status::Rejected if so.  It also outputs a simple warning.

It didn't seem there was any way to note bad orders before.