### PR TITLE
Wallet Depletion Strictness

### DIFF
--- a/src/lib/Krypto.ninja-data.h
+++ b/src/lib/Krypto.ninja-data.h
@@ -2407,10 +2407,10 @@ namespace ₿ {
       void applyDepleted() {
         const double epsilon = pow(10, -1 * K.gateway->decimal.amount.stream.precision());
         if (!quotes.bid.empty()
-          and quotes.bid.size > wallet.quote.amount / quotes.bid.price - epsilon
+          and quotes.bid.size > wallet.quote.amount * (1 - K.gateway->makeFee) / quotes.bid.price - epsilon
         ) quotes.bid.clear(mQuoteState::DepletedFunds);
         if (!quotes.ask.empty()
-          and quotes.ask.size > wallet.base.amount - epsilon
+          and quotes.ask.size > wallet.base.amount * (1 - K.gateay->makeFee) - epsilon
         ) quotes.ask.clear(mQuoteState::DepletedFunds);
       };
       void applyWaitingPing() {

--- a/src/lib/Krypto.ninja-data.h
+++ b/src/lib/Krypto.ninja-data.h
@@ -2407,12 +2407,10 @@ namespace ₿ {
       void applyDepleted() {
         const double epsilon = pow(10, -1 * K.gateway->decimal.amount.stream.precision());
         if (!quotes.bid.empty()
-          and abs(quotes.bid.size - (K.gateway->decimal.price.truncate(wallet.quote.total) / quotes.bid.price)) > epsilon
-          and quotes.bid.size > K.gateway->decimal.price.truncate(wallet.quote.total) / quotes.bid.price
+          and quotes.bid.size > wallet.quote.amount / quotes.bid.price - epsilon
         ) quotes.bid.clear(mQuoteState::DepletedFunds);
         if (!quotes.ask.empty()
-          and abs(quotes.ask.size - wallet.base.total) > epsilon
-          and quotes.ask.size > wallet.base.total
+          and quotes.ask.size > wallet.base.amount - epsilon
         ) quotes.ask.clear(mQuoteState::DepletedFunds);
       };
       void applyWaitingPing() {

--- a/src/lib/Krypto.ninja-data.h
+++ b/src/lib/Krypto.ninja-data.h
@@ -2410,7 +2410,7 @@ namespace ₿ {
           and quotes.bid.size > wallet.quote.amount * (1 - K.gateway->makeFee) / quotes.bid.price - epsilon
         ) quotes.bid.clear(mQuoteState::DepletedFunds);
         if (!quotes.ask.empty()
-          and quotes.ask.size > wallet.base.amount * (1 - K.gateay->makeFee) - epsilon
+          and quotes.ask.size > wallet.base.amount * (1 - K.gateway->makeFee) - epsilon
         ) quotes.ask.clear(mQuoteState::DepletedFunds);
       };
       void applyWaitingPing() {

--- a/src/lib/Krypto.ninja-data.h
+++ b/src/lib/Krypto.ninja-data.h
@@ -2393,14 +2393,14 @@ namespace ₿ {
           quotes.bid.size = K.gateway->decimal.amount.truncate(
             fmax(K.gateway->minSize, fmin(
               quotes.bid.size,
-              (K.gateway->decimal.price.truncate(wallet.quote.total) * (1 - K.gateway->takeFee)) / quotes.bid.price
+              (K.gateway->decimal.price.truncate(wallet.quote.amount) * (1 - K.gateway->makeFee)) / quotes.bid.price
             ))
           );
         if (!quotes.ask.empty())
           quotes.ask.size = K.gateway->decimal.amount.truncate(
             fmax(K.gateway->minSize, fmin(
               quotes.ask.size,
-              wallet.base.total
+              wallet.base.amount * (1 - K.gateway->makeFee)
             ))
           );
       };


### PR DESCRIPTION
This tightens up wallet depletion handling to prevent orders from exceeding available balance.

I got an e-mail from coinbase regarding too many failed orders.  It ended up being mostly from a combination of this and a mistake in #914 that I have force-pushed a fix for (was using fairvalue instead of market value).