### PR TITLE
Fixes for wallet size limits.

### DIFF
--- a/src/lib/Krypto.ninja-data.h
+++ b/src/lib/Krypto.ninja-data.h
@@ -2393,7 +2393,7 @@ namespace ₿ {
           quotes.bid.size = K.gateway->decimal.amount.truncate(
             fmax(K.gateway->minSize, fmin(
               quotes.bid.size,
-              wallet.quote.amount * quotes.bid.price / (1.0 + K.gateway->makeFee)
+              wallet.quote.amount / (quotes.bid.price * (1.0 + K.gateway->makeFee))
             ))
           );
         if (!quotes.ask.empty())
@@ -2407,10 +2407,10 @@ namespace ₿ {
       void applyDepleted() {
         const double epsilon = pow(10, -1 * K.gateway->decimal.amount.stream.precision());
         if (!quotes.bid.empty()
-          and quotes.bid.size > wallet.quote.amount * quotes.bid.price / (1.0 + K.gateway->makeFee) - epsilon
+          and wallet.quote.amount - quotes.bid.size * quotes.bid.price * (1.0 + K.gateway->makeFee) < epsilon
         ) quotes.bid.clear(mQuoteState::DepletedFunds);
         if (!quotes.ask.empty()
-          and quotes.ask.size > wallet.base.amount / (1.0 + K.gateway->makeFee) - epsilon
+          and wallet.base.amount - quotes.ask.size * (1.0 + K.gateway->makeFee) < epsilon
         ) quotes.ask.clear(mQuoteState::DepletedFunds);
       };
       void applyWaitingPing() {

--- a/src/lib/Krypto.ninja-data.h
+++ b/src/lib/Krypto.ninja-data.h
@@ -2393,26 +2393,24 @@ namespace ₿ {
           quotes.bid.size = K.gateway->decimal.amount.truncate(
             fmax(K.gateway->minSize, fmin(
               quotes.bid.size,
-              (K.gateway->decimal.price.truncate(wallet.quote.total) * (1 - K.gateway->takeFee)) / quotes.bid.price
+              wallet.quote.amount * quotes.bid.price / (1.0 + K.gateway->makeFee)
             ))
           );
         if (!quotes.ask.empty())
           quotes.ask.size = K.gateway->decimal.amount.truncate(
             fmax(K.gateway->minSize, fmin(
               quotes.ask.size,
-              wallet.base.total
+              wallet.base.amount / (1.0 + K.gateway->makeFee)
             ))
           );
       };
       void applyDepleted() {
         const double epsilon = pow(10, -1 * K.gateway->decimal.amount.stream.precision());
         if (!quotes.bid.empty()
-          and abs(quotes.bid.size - (K.gateway->decimal.price.truncate(wallet.quote.total) / quotes.bid.price)) > epsilon
-          and quotes.bid.size > K.gateway->decimal.price.truncate(wallet.quote.total) / quotes.bid.price
+          and quotes.bid.size > wallet.quote.amount * quotes.bid.price / (1.0 + K.gateway->makeFee) - epsilon
         ) quotes.bid.clear(mQuoteState::DepletedFunds);
         if (!quotes.ask.empty()
-          and abs(quotes.ask.size - wallet.base.total) > epsilon
-          and quotes.ask.size > wallet.base.total
+          and quotes.ask.size > wallet.base.amount / (1.0 + K.gateway->makeFee) - epsilon
         ) quotes.ask.clear(mQuoteState::DepletedFunds);
       };
       void applyWaitingPing() {


### PR DESCRIPTION
This is a squash, rebase, and fixup for #919.

- account for maker fee at all steps
- don't attempt to spend held balances ('total' becomes 'amount')
- remove some redundant checks and truncations