### PR TITLE
Add option to take percentage of side balance only

### DIFF
--- a/src/bin/trading-bot/client/main.ts
+++ b/src/bin/trading-bot/client/main.ts
@@ -97,6 +97,7 @@ class DisplayOrder {
                                         <th title="Multiplicates trades to rise the possible Trades per Minute if sop is in Trades or tradesSize state." *ngIf="[1,3].indexOf(pair.quotingParameters.display.superTrades)>-1">sopTrades</th>
                                         <th title="Multiplicates width if sop is in Size or tradesSize state." *ngIf="[2,3].indexOf(pair.quotingParameters.display.superTrades)>-1">sopSize</th>
                                         </ng-container>
+                                        <th title="Total funds to take percentage of when calculating order size." *ngIf="pair.quotingParameters.display.percentageValues">ordPctTot</th>
                                         <th title="Maximum bid size of our quote in BTC (ex. a value of 1.5 is 1.5 bitcoins). With the exception for when apr is checked and the system is aggressively rebalancing positions after they get out of whack." [attr.colspan]="pair.quotingParameters.display.aggressivePositionRebalancing ? '2' : '1'"><span *ngIf="pair.quotingParameters.display.aggressivePositionRebalancing && pair.quotingParameters.display.buySizeMax">minB</span><span *ngIf="!pair.quotingParameters.display.aggressivePositionRebalancing || !pair.quotingParameters.display.buySizeMax">b</span>idSize<span *ngIf="pair.quotingParameters.display.percentageValues">%</span><span *ngIf="pair.quotingParameters.display.aggressivePositionRebalancing" style="float:right;">maxBidSize?</span></th>
                                         <th title="Maximum ask size of our quote in BTC (ex. a value of 1.5 is 1.5 bitcoins). With the exception for when apr is checked and the system is aggressively rebalancing positions after they get out of whack." [attr.colspan]="pair.quotingParameters.display.aggressivePositionRebalancing ? '2' : '1'"><span *ngIf="pair.quotingParameters.display.aggressivePositionRebalancing && pair.quotingParameters.display.sellSizeMax">minA</span><span *ngIf="!pair.quotingParameters.display.aggressivePositionRebalancing || !pair.quotingParameters.display.sellSizeMax">a</span>skSize<span *ngIf="pair.quotingParameters.display.percentageValues">%</span><span *ngIf="pair.quotingParameters.display.aggressivePositionRebalancing" style="float:right;">maxAskSize?</span></th>
                                     </tr>
@@ -175,6 +176,12 @@ class DisplayOrder {
                                                [(ngModel)]="pair.quotingParameters.display.sopSizeMultiplier">
                                         </td>
                                         </ng-container>
+                                        <td style="border-bottom: 3px solid #D64A4A" *ngIf="pair.quotingParameters.display.percentageValues">
+                                          <select class="form-control input-sm"
+                                            [(ngModel)]="pair.quotingParameters.display.orderPctTotal">
+                                            <option *ngFor="let option of pair.quotingParameters.availableOrderPctTotals" [ngValue]="option.val">{{option.str}}</option>
+                                          </select>
+                                        </td>
                                         <td style="width:169px;border-bottom: 3px solid #D64A4A;" *ngIf="!pair.quotingParameters.display.percentageValues">
                                             <input class="form-control input-sm" title="{{ baseCurrency }}"
                                                type="number" step="0.01" min="0.01"

--- a/src/bin/trading-bot/client/models.ts
+++ b/src/bin/trading-bot/client/models.ts
@@ -171,6 +171,7 @@ export class TwoSidedQuoteStatus {
 }
 
 export enum QuotingMode { Top, Mid, Join, InverseJoin, InverseTop, HamelinRat, Depth }
+export enum OrderPctTotal { Value, Side }
 export enum QuotingSafety { Off, PingPong, PingPoing, Boomerang, AK47 }
 export enum FairValueModel { BBO, wBBO, rwBBO }
 export enum AutoPositionMode { Manual, EWMA_LS, EWMA_LMS, EWMA_4 }
@@ -188,6 +189,7 @@ export interface QuotingParameters {
     widthPongPercentage?: number;
     widthPercentage?: boolean;
     bestWidth?: boolean;
+    orderPctTotal?: OrderPctTotal;
     buySize?: any;
     buySizePercentage?: number;
     buySizeMax?: boolean;

--- a/src/bin/trading-bot/client/pair.ts
+++ b/src/bin/trading-bot/client/pair.ts
@@ -65,6 +65,7 @@ class QuotingButtonViewModel extends FormViewModel<any> {
 
 class DisplayQuotingParameters extends FormViewModel<Models.QuotingParameters> {
   availableQuotingModes = [];
+  availableOrderPctTotals = [];
   availableQuotingSafeties = [];
   availableFvModels = [];
   availableAutoPositionModes = [];
@@ -86,6 +87,7 @@ class DisplayQuotingParameters extends FormViewModel<Models.QuotingParameters> {
     });
 
     this.availableQuotingModes = DisplayQuotingParameters.getMapping(Models.QuotingMode);
+    this.availableOrderPctTotals = DisplayQuotingParameters.getMapping(Models.OrderPctTotal);
     this.availableQuotingSafeties = DisplayQuotingParameters.getMapping(Models.QuotingSafety);
     this.availableFvModels = DisplayQuotingParameters.getMapping(Models.FairValueModel);
     this.availableAutoPositionModes = DisplayQuotingParameters.getMapping(Models.AutoPositionMode);


### PR DESCRIPTION
I made this change locally to prevent exhausting my wallets.
It lets the user change the order size behavior so that only a percentage of what is available is used.

Sorry I haven't made more tests yet, finding it a bit of a barrier and thought I'd focus on what I needed for my setup a little.