### PR TITLE
Prevent unprofitable pong matches

### DIFF
--- a/src/lib/Krypto.ninja-data.h
+++ b/src/lib/Krypto.ninja-data.h
@@ -2305,26 +2305,28 @@ namespace ₿ {
           ? qp.widthPongPercentage * levels.fairValue / 100
           : qp.widthPong;
         if (!quotes.ask.empty() and wallet.safety.buyPing) {
+          const Price sellPong = (wallet.safety.buyPing * (1 + K.gateway->makeFee) + widthPong) / (1 - K.gateway->makeFee);
           if ((qp.aggressivePositionRebalancing == mAPR::SizeWidth and sideAPR == mSideAPR::Sell)
             or ((qp.safety == mQuotingSafety::PingPong or qp.safety == mQuotingSafety::PingPoing)
-              ? quotes.ask.price < wallet.safety.buyPing + widthPong
+              ? quotes.ask.price < sellPong
               : qp.pongAt == mPongAt::ShortPingAggressive
                 or qp.pongAt == mPongAt::AveragePingAggressive
                 or qp.pongAt == mPongAt::LongPingAggressive
             )
-          ) quotes.ask.price = max(levels.bids.at(0).price + K.gateway->minTick, wallet.safety.buyPing + widthPong);
-          quotes.ask.isPong = quotes.ask.price >= wallet.safety.buyPing + widthPong;
+          ) quotes.ask.price = max(levels.bids.at(0).price + K.gateway->minTick, sellPong);
+          quotes.ask.isPong = quotes.ask.price >= sellPong;
         }
         if (!quotes.bid.empty() and wallet.safety.sellPing) {
+          const Price buyPong = (wallet.safety.sellPing * (1 - K.gateway->makeFee) - widthPong) / (1 + K.gateway->makeFee);
           if ((qp.aggressivePositionRebalancing == mAPR::SizeWidth and sideAPR == mSideAPR::Buy)
             or ((qp.safety == mQuotingSafety::PingPong or qp.safety == mQuotingSafety::PingPoing)
-              ? quotes.bid.price > wallet.safety.sellPing - widthPong
+              ? quotes.bid.price > buyPong
               : qp.pongAt == mPongAt::ShortPingAggressive
                 or qp.pongAt == mPongAt::AveragePingAggressive
                 or qp.pongAt == mPongAt::LongPingAggressive
             )
-          ) quotes.bid.price = min(levels.asks.at(0).price - K.gateway->minTick, wallet.safety.sellPing - widthPong);
-          quotes.bid.isPong = quotes.bid.price <= wallet.safety.sellPing - widthPong;
+          ) quotes.bid.price = min(levels.asks.at(0).price - K.gateway->minTick, buyPong);
+          quotes.bid.isPong = quotes.bid.price <= buyPong;
         }
       };
       void applyAK47Increment() {

--- a/src/lib/Krypto.ninja-data.h
+++ b/src/lib/Krypto.ninja-data.h
@@ -1284,17 +1284,17 @@ namespace ₿ {
             ? qp.widthPongPercentage * filled.price / 100
             : qp.widthPong;
           map<Price, string> matches;
-          for (mOrderFilled &it : rows)
+          for (mOrderFilled &it : rows) {
             if (it.quantity - it.Kqty > 0
               and it.side != filled.side
-              and (qp.pongAt == mPongAt::AveragePingFair
-                or qp.pongAt == mPongAt::AveragePingAggressive
-                or (filled.side == Side::Bid
-                  ? (it.price > filled.price + widthPong)
-                  : (it.price < filled.price - widthPong)
-                )
-              )
-            ) matches[it.price] = it.tradeId;
+            ) {
+              Price combinedFee = K.gateway->makeFee * (it.price + filled.price);
+              if (filled.side == Side::Bid
+                  ? (it.price > filled.price + widthPong + combinedFee)
+                  : (it.price < filled.price - widthPong - combinedFee)
+              ) matches[it.price] = it.tradeId;
+            }
+          }
           matchPong(
             matches,
             filled,

--- a/test/units.h
+++ b/test/units.h
@@ -641,6 +641,7 @@ namespace ₿ {
             if (trade.Kdiff) {
               actualDiff += diff;
               expectedDiff += trade.Kdiff;
+              REQUIRE(trade.Kdiff > 0);
             }
           }
           REQUIRE(abs(actualBaseDelta - expectedBaseDelta) < 0.000000000001);


### PR DESCRIPTION
This changes the pong matching behavior to prevent any that would be losses, even when AveragePingFair for example is used.

I also added a quick check to make sure the diff is greater than the fee.  This might be changed when fees are more fully implemented in the mOrderFilled structure.

Since there are no longer negative Kdiffs in the testing scenario, I also added the test commit in my crosspongs-plusbug branch from https://github.com/ctubio/Krypto-trading-bot/pull/911#issuecomment-480233698 .