### PR TITLE
Allow for custom minsize if exchange data is stale/wrong.

### DIFF
--- a/src/lib/Krypto.ninja-apis.h
+++ b/src/lib/Krypto.ninja-apis.h
@@ -514,7 +514,7 @@ namespace ₿ {
         } else
           reply = handshake();
         minTick = reply.value("minTick", 0.0);
-        minSize = reply.value("minSize", 0.0);
+        if (!minSize) minSize = reply.value("minSize", 0.0);
         if (!makeFee) makeFee = reply.value("makeFee", 0.0);
         if (!takeFee) takeFee = reply.value("takeFee", 0.0);
         if (!file.is_open() and minTick and minSize) {

--- a/src/lib/Krypto.ninja-bots.h
+++ b/src/lib/Krypto.ninja-bots.h
@@ -442,6 +442,7 @@ namespace ₿ {
                                                "\n" "mandatory but may be 'NULL'"},
           {"maker-fee",    "AMOUNT", "0",      "set percentage of custom maker fee, like '0.1'"},
           {"taker-fee",    "AMOUNT", "0",      "set percentage of custom taker fee, like '0.1'"},
+          {"min-size",     "AMOUNT", "0",      "set custom minimum order size, like '0.01'"},
           {"http",         "URL",    "",       "set URL of alernative HTTPS api endpoint for trading"},
           {"wss",          "URL",    "",       "set URL of alernative WSS api endpoint for trading"},
           {"fix",          "URL",    "",       "set URL of alernative FIX api endpoint for trading"},
@@ -1542,6 +1543,8 @@ namespace ₿ {
           gateway->takeFee = arg<double>("taker-fee") / 1e+2;
         if (arg<double>("maker-fee"))
           gateway->makeFee = arg<double>("maker-fee") / 1e+2;
+        if (arg<double>("min-size"))
+          gateway->minSize = arg<double>("min-size");
         gateway->apikey    = arg<string>("apikey");
         gateway->secret    = arg<string>("secret");
         gateway->pass      = arg<string>("passphrase");


### PR DESCRIPTION
I found on Poloniex often trades for less than a dollar will be rejected.  Being able to tweak minSize let me work around this for now, so that my smaller trades will be large enough to be accepted.

Unfortunately I could only see the error by packet-logging.  It would be really great for the private lib to return error messages (#920).