### PR TITLE
Add percentage options to adjust order size based on TBP.

### DIFF
--- a/doc/MANUAL.md
+++ b/doc/MANUAL.md
@@ -135,9 +135,21 @@ In the web UI, there are three rows of panels with cryptic looking names and edi
 
 * `widthPong` - Minimum width (spread) of our quote in USD (ex. a value of .3 is 30 cents). Used only if previous Pings exists in the opposite side.
 
-* `bidSize` - Maximum bid size of our quote in BTC (ex. a value of 1.5 is 1.5 bitcoins). If `%` is enabled, then this is the maximum bid size as a % of the total funds (available funds + held in both sides). For example, if 20% is set, and the total funds is $100, then the maximum bid size is $20. With the exception for when `apr` is checked and the system is aggressively rebalancing positions after they get out of whack.
+* `orderPctTot` - If `%` is enabled, specify the method for calculation of `bidSize` and `askSize` as percentages.
 
-* `askSize` - Maximum ask size of our quote in BTC (ex. a value of 1.5 is 1.5 bitcoins). If `%` is enabled, then this is the maximum ask size as a % of the total funds (available funds + held in both sides). For example, if 20% is set, and the total funds is $100, then the maximum bid size is $20. With the exception for when `apr` is checked and the system is aggressively rebalancing positions after they get out of whack.
+  * `Value` - Percentage is taken of the total funds (available funds + held in both sides). For example, if 20% is set, and the total funds is $100, then the maximum bid size is $20.  This has a similar effect as to non-percentage-based sizes, but allows for bid sizes to adjust to funds quantity.
+
+  * `Side` - Percentage is taken of funds only on one side.  For example, if 20% is set, and quote funds are worth 20$, and base funds are worth $80, then buys will placed for 4$ and sells will placed for $16.  This allows trading to continue even when funds on one side are heavily depleted, but results in held balances trending towards being evenly distributed.
+
+  * `TBPValue` - Percentage is taken of the total funds as in `Value`, but either the sell size or buy size is shrunk proportional to the value of the TBP, such that the balances will move towards being bought or sold depending on which side the TBP is.
+
+  * `TBPSide` - Percentage is taken of funds only on one side as in `Side`, but balance is taken relative to the `pDiv` extents such that they are not crossed, and either the sell size or buy size is shrunk proportional to the distance from the TBP, such that balances will tend to migrate towards the TBP.
+
+    * `exp` - If `TBPSide` is used for `orderPctTot`, this specifies the exponent to raise the size multipliers by.  The higher the number, the more the sizes will shrink as balance passes the TBP.
+
+* `bidSize` - Maximum bid size of our quote in BTC (ex. a value of 1.5 is 1.5 bitcoins). If `%` is enabled, then this is the maximum bid size as a % as specified in `orderPctTot`. With the exception for when `apr` is checked and the system is aggressively rebalancing positions after they get out of whack.
+
+* `askSize` - Maximum ask size of our quote in BTC (ex. a value of 1.5 is 1.5 bitcoins). If `%` is enabled, then this is the maximum ask size as a % as specified by `orderPctTot`. With the exception for when `apr` is checked and the system is aggressively rebalancing positions after they get out of whack.
 
 * `maxBidSize?` and `maxAskSize?` - Use `bidSize` and `askSize` as minimums and automatically find the maximum possible `size` based on the current "Target Base Position" (just as having enabled `apr` on `Size` but even before your position diverges more than `pDiv`).
 

--- a/src/bin/trading-bot/client/main.ts
+++ b/src/bin/trading-bot/client/main.ts
@@ -103,6 +103,8 @@ class DisplayOrder {
                                         <th title="Multiplicates trades to rise the possible Trades per Minute if sop is in Trades or tradesSize state." *ngIf="[1,3].indexOf(pair.quotingParameters.display.superTrades)>-1">sopTrades</th>
                                         <th title="Multiplicates width if sop is in Size or tradesSize state." *ngIf="[2,3].indexOf(pair.quotingParameters.display.superTrades)>-1">sopSize</th>
                                         </ng-container>
+                                        <th title="Total funds to take percentage of when calculating order size." *ngIf="pair.quotingParameters.display.percentageValues">ordPctTot</th>
+                                        <th title="Exponent for TBP size dropoff, higher=faster." *ngIf="pair.quotingParameters.display.orderPctTotal == 3">exp</th>
                                         <th title="Maximum bid size of our quote in BTC (ex. a value of 1.5 is 1.5 bitcoins). With the exception for when apr is checked and the system is aggressively rebalancing positions after they get out of whack." [attr.colspan]="pair.quotingParameters.display.aggressivePositionRebalancing ? '2' : '1'"><span *ngIf="pair.quotingParameters.display.aggressivePositionRebalancing && pair.quotingParameters.display.buySizeMax">minB</span><span *ngIf="!pair.quotingParameters.display.aggressivePositionRebalancing || !pair.quotingParameters.display.buySizeMax">b</span>idSize<span *ngIf="pair.quotingParameters.display.percentageValues">%</span><span *ngIf="pair.quotingParameters.display.aggressivePositionRebalancing" style="float:right;">maxBidSize?</span></th>
                                         <th title="Maximum ask size of our quote in BTC (ex. a value of 1.5 is 1.5 bitcoins). With the exception for when apr is checked and the system is aggressively rebalancing positions after they get out of whack." [attr.colspan]="pair.quotingParameters.display.aggressivePositionRebalancing ? '2' : '1'"><span *ngIf="pair.quotingParameters.display.aggressivePositionRebalancing && pair.quotingParameters.display.sellSizeMax">minA</span><span *ngIf="!pair.quotingParameters.display.aggressivePositionRebalancing || !pair.quotingParameters.display.sellSizeMax">a</span>skSize<span *ngIf="pair.quotingParameters.display.percentageValues">%</span><span *ngIf="pair.quotingParameters.display.aggressivePositionRebalancing" style="float:right;">maxAskSize?</span></th>
                                     </tr>
@@ -181,6 +183,18 @@ class DisplayOrder {
                                                [(ngModel)]="pair.quotingParameters.display.sopSizeMultiplier">
                                         </td>
                                         </ng-container>
+                                        <td style="border-bottom: 3px solid #D64A4A" *ngIf="pair.quotingParameters.display.percentageValues">
+                                          <select class="form-control input-sm"
+                                            [(ngModel)]="pair.quotingParameters.display.orderPctTotal">
+                                            <option *ngFor="let option of pair.quotingParameters.availableOrderPctTotals" [ngValue]="option.val">{{option.str}}</option>
+                                          </select>
+                                        </td>
+                                        <td style="border-bottom: 3px solid #D64A4A;" *ngIf="pair.quotingParameters.display.orderPctTotal == 3">
+                                            <input class="form-control input-sm" title="{{ baseCurrency }}"
+                                               type="number" step="0.001" min="1" max="16"
+                                               onClick="this.select()"
+                                               [(ngModel)]="pair.quotingParameters.display.tradeSizeTBPExp">
+                                        </td>
                                         <td style="width:169px;border-bottom: 3px solid #D64A4A;" *ngIf="!pair.quotingParameters.display.percentageValues">
                                             <input class="form-control input-sm" title="{{ baseCurrency }}"
                                                type="number" step="{{ product.advert.tickSize}}" min="{{ product.advert.minSize}}"

--- a/src/bin/trading-bot/client/models.ts
+++ b/src/bin/trading-bot/client/models.ts
@@ -171,6 +171,7 @@ export class TwoSidedQuoteStatus {
 }
 
 export enum QuotingMode { Top, Mid, Join, InverseJoin, InverseTop, HamelinRat, Depth }
+export enum OrderPctTotal { Value, Side, TBPValue, TBPSide }
 export enum QuotingSafety { Off, PingPong, PingPoing, Boomerang, AK47 }
 export enum FairValueModel { BBO, wBBO, rwBBO }
 export enum AutoPositionMode { Manual, EWMA_LS, EWMA_LMS, EWMA_4 }
@@ -188,6 +189,7 @@ export interface QuotingParameters {
     widthPongPercentage?: number;
     widthPercentage?: boolean;
     bestWidth?: boolean;
+    orderPctTotal?: OrderPctTotal;
     buySize?: any;
     buySizePercentage?: number;
     buySizeMax?: boolean;

--- a/src/bin/trading-bot/client/pair.ts
+++ b/src/bin/trading-bot/client/pair.ts
@@ -65,6 +65,7 @@ class QuotingButtonViewModel extends FormViewModel<any> {
 
 class DisplayQuotingParameters extends FormViewModel<Models.QuotingParameters> {
   availableQuotingModes = [];
+  availableOrderPctTotals = [];
   availableQuotingSafeties = [];
   availableFvModels = [];
   availableAutoPositionModes = [];
@@ -86,6 +87,7 @@ class DisplayQuotingParameters extends FormViewModel<Models.QuotingParameters> {
     });
 
     this.availableQuotingModes = DisplayQuotingParameters.getMapping(Models.QuotingMode);
+    this.availableOrderPctTotals = DisplayQuotingParameters.getMapping(Models.OrderPctTotal);
     this.availableQuotingSafeties = DisplayQuotingParameters.getMapping(Models.QuotingSafety);
     this.availableFvModels = DisplayQuotingParameters.getMapping(Models.FairValueModel);
     this.availableAutoPositionModes = DisplayQuotingParameters.getMapping(Models.AutoPositionMode);


### PR DESCRIPTION
This is a resubmission of my PR to add an option to tune how order size percentages are taken.

When `%` mode is enabled, an `orderPctTot` option appears providing to set how to select size percentages.

The different options provide for taking the percentages of the balances in different ways, such that how the balance evolves is different.  For example, you can have bid sizes for USD shrink very tiny when you have already sold most of your USD.  This lets you keep trading a little when far from the TBP.

The TBPSide option tunes the parameters such that each size reaches 0 at the `pdiv` extents, and they are equal at `TBP`.