### PR TITLE
Fix TBP limit

### DIFF
--- a/src/bin/trading-bot/trading-bot.data.h
+++ b/src/bin/trading-bot/trading-bot.data.h
@@ -1728,21 +1728,8 @@ namespace tribeca {
               ? qp.targetBasePositionPercentage * baseValue / 1e+2
               : qp.targetBasePosition)
             : (qp.percentageValues
-              ? fmin(
-                  fmax(
-                    targetPositionAutoPercentage,
-                    qp.targetBasePositionPercentageMin
-                  ),
-                  qp.targetBasePositionPercentageMax
-                ) * baseValue / 1e+2
-              : fmin(
-                  fmax(
-                    targetPositionAutoPercentage * baseValue / 1e+2,
-                    qp.targetBasePositionMin
-                  ),
-                  qp.targetBasePositionMax
-                )
-            )
+              ? ( qp.targetBasePositionPercentageMin + ( qp.targetBasePositionPercentageMax - qp.targetBasePositionPercentageMin ) * targetPositionAutoPercentage / 1e+2 ) / 1e+2 * baseValue
+              : ( qp.targetBasePositionMin + ( qp.targetBasePositionMax - qp.targetBasePositionMin ) * targetPositionAutoPercentage / 1e+2 ) / 1e+2 * baseValue)
         );
         calcPDiv();
         if (broadcast()) {

--- a/src/bin/trading-bot/trading-bot.data.h
+++ b/src/bin/trading-bot/trading-bot.data.h
@@ -1729,7 +1729,7 @@ namespace tribeca {
               : qp.targetBasePosition)
             : (qp.percentageValues
               ? ( qp.targetBasePositionPercentageMin + ( qp.targetBasePositionPercentageMax - qp.targetBasePositionPercentageMin ) * targetPositionAutoPercentage / 1e+2 ) / 1e+2 * baseValue
-              : ( qp.targetBasePositionMin + ( qp.targetBasePositionMax - qp.targetBasePositionMin ) * targetPositionAutoPercentage / 1e+2 ) / 1e+2 * baseValue)
+              : ( qp.targetBasePositionMin + ( qp.targetBasePositionMax - qp.targetBasePositionMin ) * targetPositionAutoPercentage / 1e+2 ))
         );
         calcPDiv();
         if (broadcast()) {


### PR DESCRIPTION
The previous TBP limiter was clipping to a region of TBP instead of mapping to it. For example if the tbp limits are 10% to 20%, if the TBP engine calculated 0%, 5%, 50% and 100% the old code clipped those to 10, 10, 20, 20. 

This update converts this clipping to mapping. The above values are now accordingly mapped to 10%, 10.5%, 15% and 20%.