### PR TITLE
Update Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ ABI       ?= $(shell echo '\#include <string>'             \
                | grep '_GLIBCXX_USE_CXX11_ABI 1'           \
                | wc -l | tr -d ' '                         )
 
-KHOST     := $(shell echo $(CHOST)                               \
+KHOST     ?= $(shell echo $(CHOST)                               \
                | sed 's/-\([a-z_0-9]*\)-\(linux\)$$/-\2-\1/'     \
                | sed 's/\([a-z_0-9]*\)-\([a-z_0-9]*\)-.*/\2-\1/' \
                | sed 's/^w64/win64/'                             )


### PR DESCRIPTION
When building the Dockerfile pointing to the latest Ubuntu LTS release, the property KHOST is not filled properly, and we cannot configure it from outside since we are using `:=` instead of `?=`. Proposing a change for more flexibility.