### PR TITLE
Fix inconsistent spacing in stdlog

### DIFF
--- a/src/bin/scaling-bot/scaling-bot.data.h
+++ b/src/bin/scaling-bot/scaling-bot.data.h
@@ -58,7 +58,7 @@ namespace analpaper {
         if (last.filled) K.gateway->askForFees = true;
         if (order->isPong or last.filled)
           K.log("GW " + K.gateway->exchange, string(order->isPong?"PONG":"PING") + " TRADE "
-            + (order->side == Side::Bid ? "BUY  " : "SELL ")
+            + (order->side == Side::Bid ? "BUY " : "SELL ")
             + K.gateway->decimal.amount.str(order->isPong ? order->quantity : last.filled)
             + " " + K.gateway->base + " at "
             + K.gateway->decimal.price.str(order->price)

--- a/src/bin/trading-bot/trading-bot.data.h
+++ b/src/bin/trading-bot/trading-bot.data.h
@@ -1301,7 +1301,7 @@ namespace tribeca {
         };
         const bool is_bid = order.side == Side::Bid;
         K.log("GW " + K.gateway->exchange, string(order.isPong?"PONG":"PING") + " TRADE "
-          + (is_bid ? "BUY  " : "SELL ")
+          + (is_bid ? "BUY " : "SELL ")
           + K.gateway->decimal.amount.str(filled.quantity) + ' '
           + (K.gateway->margin == Future::Spot ? K.gateway->base : "Contracts") + " at price "
           + K.gateway->decimal.price.str(filled.price) + ' ' + K.gateway->quote + " (value "


### PR DESCRIPTION
It is currently "BUY{SPACE}{SPACE}" but "SELL{SPACE}". If you have a reason for this feel free to reject, it's just making log monitoring a pain for me currently.