### PR TITLE
Docker container goes brrrr (slim down image size)

### DIFF
--- a/etc/Dockerfile
+++ b/etc/Dockerfile
@@ -1,7 +1,8 @@
-FROM overlordq/8-buster
+FROM debian:buster-slim
+
 
 RUN apt-get update \
- && apt-get install --no-install-recommends -y git sudo
+    && apt-get install --no-install-recommends -y git sudo make ca-certificates curl g++
 
 # Feel free to choose the branch you want to build:
 RUN git clone -b master https://github.com/ctubio/Krypto-trading-bot.git /K


### PR DESCRIPTION
Currently, building on docker takes 

```
market-maker: 991 MBs
overlordq/8-buster: 826 MBs
```
![DOCKERFAT](https://user-images.githubusercontent.com/53630064/113001771-b5291f80-91a3-11eb-93bf-6cd81d23db65.png)

Changing the base image will reduce this to

```
market-maker: 400 Mbs
debian:buster-slim: ~26.47
```

I'm not sure why you kept that image, it hasn't been updated for two years and the original Dockerfile [can't be found](https://github.com/OverlordQ/8-buster).
Hope this PR is helpful!